### PR TITLE
suggestion(01_variable): exerices et solutions

### DIFF
--- a/exercises/01_variables/variables5.rs
+++ b/exercises/01_variables/variables5.rs
@@ -1,8 +1,8 @@
 fn main() {
    let number = "T-R-O-I-S"; // Ne change pas cette ligne
-   println!("Épelle un nombre: {}", number);
+   println!("Épelle un nombre : {}", number);
 
    // TODO: Corrige l'erreur du compilateur en changeant la ligne ci-dessous sans renommer la variable.
    number = 3;
-   println!("Le nombre plus deux égal: {}", number + 2);
+   println!("Le nombre plus deux égale : {}", number + 2);
 }

--- a/info.toml
+++ b/info.toml
@@ -46,15 +46,15 @@ test = false
 hint = """
 Le message du compilateur indique que Rust ne peut pas déduire le type de la variable `x` avec ce qui est actuellement écrit.
 
-Que se passe-t-il si tu annotes la première ligne dans la fonction `main` avec un type?
+Que se passe-t-il si tu annotes la première ligne dans la fonction `main` avec un type ?
 
-Que se passe-t-il si tu donnes une valeur à `x`?
+Que se passe-t-il si tu donnes une valeur à `x` ?
 
-Que se passe-t-il si tu fais les deux?
+Que se passe-t-il si tu fais les deux ?
 
-Quel type devrait avoir `x`, de toute façon?
+Quel type devrait avoir `x`, de toute façon ?
 
-Et si `x` est du même type que `10`? Et s'il est d'un type différent?"""
+Et si `x` est du même type que `10` ? Et s'il est d'un type différent ?"""
 
 [[exercises]]
 name = "variables3"
@@ -79,7 +79,7 @@ name = "variables5"
 dir = "01_variables"
 test = false
 hint = """
-Dans `variables4`, nous avons déjà appris comment rendre une variable immuable mutable en utilisant un mot-clé spécial. Malheureusement, cela ne nous aide pas beaucoup dans cet exercice car nous voulons assigner une valeur de type différent à une variable existante. Parfois, tu peux aussi vouloir réutiliser des noms de variables existants parce que tu convertis simplement des valeurs vers différents types comme dans cet exercice.
+Dans `variables4`, nous avons déjà appris comment rendre une variable immuable mutable en utilisant un mot-clé spécial. Malheureusement, cela ne nous aide pas beaucoup dans cet exercice car nous voulons assigner à une variable existante une valeur de type différent. Parfois, tu peux aussi vouloir réutiliser des noms de variables existants parce que tu convertis simplement des valeurs vers différents types comme dans cet exercice.
 Heureusement, Rust a une solution puissante à ce problème : le 'Shadowing' (masquage) !
 Tu peux en savoir plus sur le 'Masquage' dans la section 'Les variables et la mutabilité' du Rust Book(fr) :
 https://jimskapt.github.io/rust-book-fr/ch03-01-variables-and-mutability.html#le-masquage

--- a/solutions/01_variables/variables2.rs
+++ b/solutions/01_variables/variables2.rs
@@ -4,8 +4,8 @@ fn main() {
     // comme `i32` qui est le type par défaut pour les entiers.
     let x = 42;
 
-    // Mais nous pouvons imposer un type différent du `i32` par défaut en ajoutant
-    // une annotation de type:
+    // Mais nous pouvons imposer un type différent de `i32` par défaut en ajoutant
+    // une annotation de type :
     // let x: u8 = 42;
 
     if x == 10 {

--- a/solutions/01_variables/variables5.rs
+++ b/solutions/01_variables/variables5.rs
@@ -5,5 +5,5 @@ fn main() {
     // Utilisation du masquage (shadowing) de variable
     // https://jimskapt.github.io/rust-book-fr/ch03-01-variables-and-mutability.html#le-masquage
     let number = 3;
-    println!("Le nombre plus deux egale : {}", number + 2);
+    println!("Le nombre plus deux égale : {}", number + 2);
 }


### PR DESCRIPTION
exercises/01_variables/variables5.rs:
- ajout d'espaces avant `:`
- manque un `e` à `égal`

solutions/01_variables/variables2.rs:
- ajout d'espace avant `:`
- "de `i32`" au lieu "du `i32`

solutions/01_variables/variables5.rs:
- manque un accent à `egale`

info.toml:
- ajoute un espace avant les `?`.
- `nous voulons assigner une valeur de type différent à une variable existante` -> `nous voulons assigner à une variable existante une valeur de t
ype différent`