### PR TITLE
suggestion(02_functions): exercices et solutions

### DIFF
--- a/exercises/02_functions/README.md
+++ b/exercises/02_functions/README.md
@@ -1,7 +1,7 @@
-# Functions
+# Fonctions
 
 Ici, tu vas apprendre comment écrire des fonctions et comment le compilateur Rust peut t'aider à déboguer des erreurs même dans du code plus complexe.
 
 ## Informations complémentaires
 
-- [Comment fonctionnent les Functions](https://jimskapt.github.io/rust-book-fr/ch03-03-how-functions-work.html#les-fonctions)
+- [Comment fonctionnent les Fonctions](https://jimskapt.github.io/rust-book-fr/ch03-03-how-functions-work.html#les-fonctions)

--- a/exercises/02_functions/functions2.rs
+++ b/exercises/02_functions/functions2.rs
@@ -1,7 +1,7 @@
 // TODO: Ajoute le type manquant de l'argument `num` après les deux-points `:`.
 fn call_me(num:) {
     for i in 0..num {
-        println!("Ring! Call number {}", i + 1);
+        println!("Dring ! Appel numéro {}", i + 1);
     }
 }
 

--- a/exercises/02_functions/functions4.rs
+++ b/exercises/02_functions/functions4.rs
@@ -1,4 +1,4 @@
-// Ce magasin fait une promotion, si le prix est un nombre pair, tu obtiens 10
+// Ce magasin fait une promotion : si le prix est un nombre pair, tu obtiens 10
 // Rustbucks de réduction, mais si c'est un nombre impair, c'est 3 Rustbucks de réduction.
 // Ne t'inquiète pas pour le corps des fonctions, nous sommes seulement intéressés par
 // les signatures pour l'instant.

--- a/info.toml
+++ b/info.toml
@@ -136,7 +136,7 @@ test = false
 hint = """
 C'est une erreur très courante qui peut être corrigée en supprimant un seul caractère. 
 Elle se produit parce que Rust fait la distinction entre les expressions et les instructions :
-Les expressions renvoient une valeur basée sur leur(s) opérande(s), tandis que les instructions renvoient simplement 
+les expressions renvoient une valeur basée sur leur(s) opérande(s), tandis que les instructions renvoient simplement 
 un type `()` qui se comporte comme `void` en C/C++.
 Nous voulons renvoyer une valeur de type `i32` de la fonction `square`, mais
 elle renvoie le type `()`.

--- a/solutions/02_functions/functions2.rs
+++ b/solutions/02_functions/functions2.rs
@@ -1,4 +1,4 @@
-// Le type des arguments de fonction doit être annoté.
+// Le type des arguments d'une fonction doit être annoté.
 // Type d'annotation `u64` ajouté.
 fn call_me(num: u64) {
     for i in 0..num {

--- a/solutions/02_functions/functions4.rs
+++ b/solutions/02_functions/functions4.rs
@@ -13,5 +13,5 @@ fn sale_price(price: i64) -> i64 {
 
 fn main() {
     let original_price = 51;
-    println!("Ton prix soldé est {}", sale_price(original_price));
+    println!("Ton prix en promotion est {}", sale_price(original_price));
 }


### PR DESCRIPTION
exercises/02_functions/function2.rs:
- Le contenu de println! n'était pas traduit.

exercises/02_functions/function4.rs:
- `Ce magasin fait une promotion, si le prix...` -> `Ce magasin fait une promotion : si le prix...`

exercises/02_functions/README.md:
- `Fonctions` au lieu de `Functions`.

solutions/02_functions/function2.rs
- `Le type des arguments de fonction doit être annoté` -> `Le type des arguments de la fonction doit être annoté`.

solutions/02_functions/function4.rs
- Utilisation de la même traduction à l'intérieur du println! que dans l'exercice.

info.toml:
- pas de majscule après `:`.